### PR TITLE
getopt

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@
 # Process this file with autoconf to produce a configure script.
 
 AC_PREREQ([2.69])
-AC_INIT([addrinfo], [0.1], [garrett@garrettspace.net])
+AC_INIT([addrinfo], [0.1.1], [garrett@garrettspace.net])
 AC_CONFIG_SRCDIR([src/config.h.in])
 AC_CONFIG_HEADERS([config.h])
 
@@ -12,7 +12,7 @@ AC_PROG_CC
 # Checks for libraries.
 
 # Checks for header files.
-AC_CHECK_HEADERS([arpa/inet.h netdb.h netinet/in.h sys/socket.h unistd.h])
+AC_CHECK_HEADERS([arpa/inet.h netdb.h netinet/in.h sys/socket.h unistd.h getopt.h])
 
 # Checks for typedefs, structures, and compiler characteristics.
 

--- a/src/addrinfo.c
+++ b/src/addrinfo.c
@@ -2,10 +2,40 @@
 
 int main(int argc, char *argv[])
 {
-  if (argc == 2) {
+ int opt = 0;
+ int ipv4_only = 0;
+  int ipv6_only = 0;
+const char *optstring = "46";
+while ((opt = getopt(argc, argv, optstring)) != -1) {
+switch(opt) {
+case '4':
+ipv4_only = 1;
+ipv6_only = 0;
+break;
+case '6':
+ipv6_only = 1;
+ipv4_only = 0;
+break;
+default:
+usage();
+break;
+} //switch
+} //while
+  if (optind == argc ) {
+fprintf(stderr, "Error: option required after arguments\n");
+usage();
+  } //if
     struct addrinfo hints;
     memset(&hints, 0, sizeof(hints));
-    //hints.ai_family = AF_INET6;
+if (!ipv4_only && !ipv6_only) {
+hints.ai_family = AF_UNSPEC;
+} //if
+else if (ipv4_only && !ipv6_only) {
+    hints.ai_family = AF_INET;
+} //if
+else {
+hints.ai_family = AF_INET6;
+} //else
     hints.ai_flags = AI_CANONNAME;
     struct addrinfo *res = NULL;
     int gaistatus = getaddrinfo(argv[1], NULL, &hints, &res);
@@ -18,10 +48,6 @@ int main(int argc, char *argv[])
       parseaddrinfo(i);
     } //for
     freeaddrinfo(res);
-  } //if
-  else {
-    usage();
-  } //else, wrong number of args
   return 0;
 } //main
 

--- a/src/addrinfo.h
+++ b/src/addrinfo.h
@@ -11,6 +11,8 @@
   #include <stdlib.h>
   #include <arpa/inet.h>
   #include <netinet/in.h>
+#include <getopt.h>
+
   void parseaddrinfo(const struct addrinfo *ai);
   void usage(void);
 #endif //_ADDRINFO_H


### PR DESCRIPTION
- **addrinfo.h: Added includes for getopt**
- **addrinfo.c: Added logic for command line arguments. -4 = IPv4 only, -6 = IPv6 only. Last specified option wins.**
- **configure.ac: Added check for <getopt.h>.**
